### PR TITLE
Add notifier to service

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,6 +34,7 @@ class flowtools::install {
     owner   => 'root',
     group   => 'root',
     require => Package['flow-tools'],
+    notify  => Service[$flowtools::params::service_name],
   }
 
 }


### PR DESCRIPTION
Hello

This commit enhances this Puppet manifest by adding a notification relationship between the init script and the corresponding service.
Notably, any update to the init script should propagate to the running instance of the service.